### PR TITLE
feat: refine agent-spawning skills with improved patterns

### DIFF
--- a/.claude/skills/ghs-action-fix/SKILL.md
+++ b/.claude/skills/ghs-action-fix/SKILL.md
@@ -176,12 +176,14 @@ Wait for user confirmation.
 
 For each confirmed workflow:
 
+**Use absolute paths** — resolve `GHS_ROOT`, `REPO_PATH`, and `WT_DIR` once at skill start (see `agent-spawning.md` § Repository Cloning):
+
 | Step | Command | Notes |
 |------|---------|-------|
-| 1. Create worktree dir | `mkdir -p repos/{owner}_{repo}--worktrees` | Sibling to main clone |
+| 1. Create worktree dir | `mkdir -p "$WT_DIR"` | Sibling to main clone |
 | 2. Derive slug | Workflow filename without extension, kebab-case | `ci.yml` → `ci`, `code-quality.yml` → `code-quality` |
-| 3. Add worktree | `git -C repos/{owner}_{repo} worktree add ../repos/{owner}_{repo}--worktrees/fix--action-{slug} -b fix/action-{slug}` | One per workflow |
-| 4. Verify | `ls repos/{owner}_{repo}--worktrees/fix--action-{slug}/.git` | Confirm valid |
+| 3. Add worktree | `git -C "$REPO_PATH" worktree add "$WT_DIR/fix--action-{slug}" -b fix/action-{slug}` | One per workflow |
+| 4. Verify | `ls "$WT_DIR/fix--action-{slug}/.git"` | Confirm valid |
 
 ## Phase 5 — Launch CI Fix Agents
 
@@ -213,7 +215,7 @@ After all agents complete:
 - **FAILED**: Remove worktree and local branch (fix didn't work anyway)
 - **NEEDS_HUMAN**: Leave worktree in place with instructions
 
-Prune: `git -C repos/{owner}_{repo} worktree prune`
+Prune: `git -C "$REPO_PATH" worktree prune`
 
 ## Phase 8 — Final Report
 
@@ -297,4 +299,4 @@ You need write access. Check: `gh repo view --json viewerPermission`
 If logs are truncated or unclear, the agent marks NEEDS_HUMAN. Check the full logs manually: `gh run view {run_id} --log`
 
 **Worktrees not cleaned up**
-Run `git -C repos/{owner}_{repo} worktree list` and remove stale ones: `git worktree remove <path>`
+Run `git -C "$REPO_PATH" worktree list` and remove stale ones: `git worktree remove <path>`

--- a/.claude/skills/ghs-backlog-fix/SKILL.md
+++ b/.claude/skills/ghs-backlog-fix/SKILL.md
@@ -361,11 +361,13 @@ See `../shared/references/agent-spawning.md` (Pre-flight Checks section) for the
 
 Create worktrees only for the current wave's Category B/CI items:
 
+**Use absolute paths** — resolve `GHS_ROOT`, `REPO_PATH`, and `WT_DIR` once at skill start (see `agent-spawning.md` § Repository Cloning):
+
 | Step | Command | Notes |
 |------|---------|-------|
-| 1. Create worktree dir | `mkdir -p repos/{owner}_{repo}--worktrees` | Sibling to main clone, never nested inside |
-| 2. Add worktree | `git -C repos/{owner}_{repo} worktree add ../repos/{owner}_{repo}--worktrees/{prefix}--{slug} -b {prefix}/{slug}` | One worktree per Category B/CI item |
-| 3. Verify creation | `ls repos/{owner}_{repo}--worktrees/{prefix}--{slug}/.git` | Confirm worktree is valid |
+| 1. Create worktree dir | `mkdir -p "$WT_DIR"` | Sibling to main clone, never nested inside |
+| 2. Add worktree | `git -C "$REPO_PATH" worktree add "$WT_DIR/{prefix}--{slug}" -b {prefix}/{slug}` | One worktree per Category B/CI item |
+| 3. Verify creation | `ls "$WT_DIR/{prefix}--{slug}/.git"` | Confirm worktree is valid |
 
 Category A items don't need worktrees — they use `gh` API commands directly.
 
@@ -622,7 +624,7 @@ The fix has already been applied. The skill will skip it and tell you.
 You need write access to the repository. Check `gh repo view --json viewerPermission`.
 
 **Worktree creation fails**
-If the branch already exists locally: `git -C repos/{owner}_{repo} branch -D fix/{slug}` then retry.
+If the branch already exists locally: `git -C "$REPO_PATH" branch -D fix/{slug}` then retry.
 If it exists remotely: use `-B` flag to force-create, or ask user.
 
 **Agent returns NEEDS_HUMAN**
@@ -632,7 +634,7 @@ The fix requires human judgment. The worktree is left in place — `cd` into it 
 Common causes: branch already exists remotely (skill checks for this in Phase 4), or default branch is protected. Check `gh pr list --head fix/{slug}` for existing PRs.
 
 **Worktrees not cleaned up**
-Run `git -C repos/{owner}_{repo} worktree list` to see active worktrees. Remove with `git worktree remove <path>`.
+Run `git -C "$REPO_PATH" worktree list` to see active worktrees. Remove with `git worktree remove <path>`.
 
 **Wave 2 items all BLOCKED**
 This means Wave 1 dependencies failed. Fix the Wave 1 items first (check the error), then re-run. The state issue will show what failed and why.

--- a/.claude/skills/ghs-issue-implement/SKILL.md
+++ b/.claude/skills/ghs-issue-implement/SKILL.md
@@ -9,11 +9,12 @@ description: >
   Use this skill whenever the user wants to implement an issue, fix
   a bug from an issue, build a feature from an issue, or says things like "implement issue #42",
   "fix issue #42", "implement #42", "build feature from issue #15", "implement all triaged issues",
-  "implement all bugs", "work on issue #42", or "code issue #42".
+  "implement all bugs", "work on issue #42", "code issue #42", or describes work with no issue
+  number like "owner/repo refresh readme" or "owner/repo fix the broken badge".
   Do NOT use for triaging/labeling issues (use ghs-issue-triage), analyzing issues
   (use ghs-issue-analyze), applying backlog health items (use ghs-backlog-fix), or scanning
   repos (use ghs-repo-scan).
-argument-hint: "<owner/repo#number> [--all-triaged] [--all-bugs]"
+argument-hint: "<owner/repo> <#number | free-form description> [--all-triaged] [--all-bugs]"
 allowed-tools: "Bash(gh:*) Bash(git:*) Read Write Edit Glob Grep Task Skill"
 compatibility: "Requires gh CLI (authenticated), git, GSD framework (for complex issues), network access"
 license: MIT
@@ -75,6 +76,7 @@ The user must have **write access** to the target repository.
 | Pass entire scan/backlog to subagent | Pass only: issue details, repo structure, acceptance criteria, tech stack | Bloats agent context, causes confusion and hallucination |
 | Force GSD on simple issues | Use complexity routing — Low/Medium go fast path, High/Very High go GSD | GSD overhead isn't justified for a typo fix or single-file change |
 | Skip state issue check at start | Read state issue for active blockers and previous attempts | Re-trying known-blocked items wastes time and confuses users |
+| Apply `type:*` labels without checking they exist | Check existing labels first; create missing ones or fall back to repo defaults | Repos without the GHS label taxonomy will fail on `gh issue create --label` |
 
 </anti-patterns>
 
@@ -159,13 +161,14 @@ Read issue analysis comment (if exists) and state issue before implementation.
 
 ## Input
 
-Three invocation modes — the trigger phrase determines which:
+Four invocation modes — the trigger phrase determines which:
 
 | Trigger | Mode | What It Fetches |
 |---------|------|-----------------|
 | `implement issue #42`, `fix #42`, `code issue #42` | Single issue | One issue by number |
 | `implement all triaged issues` | Batch by label | Issues with `status:triaged` |
 | `implement all bugs` | Batch by type | Issues with `type:bug` |
+| `owner/repo refresh readme for .NET 10` | Create-and-implement | No issue — creates one from description |
 
 ### Rule/Trigger/Example Triples
 
@@ -184,6 +187,10 @@ Three invocation modes — the trigger phrase determines which:
 **Rule:** A closed issue is skipped unless explicitly requested.
 **Trigger:** User says "implement #42" but #42 is closed.
 **Example:** Warn the user and skip. If user insists, proceed with a note.
+
+**Rule:** No issue number + free-form text resolves to create-and-implement mode.
+**Trigger:** User says "owner/repo refresh readme" or "owner/repo fix the broken badge".
+**Example:** Investigate repo -> create issue with description -> assess complexity -> route -> implement -> PR.
 
 ## Branch Naming
 
@@ -238,6 +245,49 @@ gh issue list --repo {owner}/{repo} --state open --label "{filter_label}" \
 For each issue, extract: number, title, body, type label (for branch prefix), priority label (for ordering — critical first), comments (check for analysis from `ghs-issue-analyze`).
 
 **Analysis context:** If an issue has a comment starting with `## Issue Analysis` (from `ghs-issue-analyze`), extract and pass it to the agent. This provides affected files, suggested approach, and complexity assessment.
+
+**Create-and-implement mode (no issue number):**
+
+When the user provides a free-form description instead of an issue number (e.g., `/ghs-issue-implement owner/repo refresh readme for .NET 10`), create the issue first:
+
+1. Parse the remaining tokens after `owner/repo` as a description
+2. Investigate the repo to understand what needs to change (read relevant files via `gh api`)
+3. Determine the appropriate type label (bug, feature, docs, etc.)
+4. **Check existing labels** before applying (see Label Safety below)
+5. Create the issue:
+   ```bash
+   gh issue create --repo {owner}/{repo} \
+     --title "{type}: {concise title}" \
+     --body "{detailed description with acceptance criteria}" \
+     {--label "{type_label}" only if label exists on repo}
+   ```
+6. Continue with single-issue mode using the newly created issue number
+
+### Label Safety
+
+Before applying any labels (on issue creation or label updates), check which labels exist on the target repo:
+
+```bash
+EXISTING_LABELS=$(gh label list --repo {owner}/{repo} --json name --jq '.[].name')
+```
+
+| Scenario | Action |
+|----------|--------|
+| `type:docs` exists | Use it on `--label` flag |
+| `type:docs` does not exist but `documentation` does | Use the repo's existing label instead |
+| Neither exists | Create the issue without type labels; note in plan that labels are missing |
+| `status:triaged` does not exist | Skip applying it; suggest running `ghs-issue-triage` to set up taxonomy |
+
+**Fallback mapping** for repos using GitHub's default labels:
+
+| GHS Label | GitHub Default Equivalent |
+|-----------|--------------------------|
+| `type:bug` | `bug` |
+| `type:feature` | `enhancement` |
+| `type:docs` | `documentation` |
+| `type:hotfix` | `bug` + `priority:critical` |
+
+Never fail on a missing label — fall back gracefully or omit the label entirely.
 
 ### Phase 2 — Assess Complexity & Route
 
@@ -320,14 +370,13 @@ Wait for user confirmation before continuing.
 
 Create worktrees and spawn agents as before — this is the existing v4.0 behavior.
 
-Per `../shared/references/agent-spawning.md` § Worktree Creation:
+Per `../shared/references/agent-spawning.md` § Worktree Creation. **Use absolute paths** — resolve `GHS_ROOT`, `REPO_PATH`, and `WT_DIR` once at skill start (see agent-spawning.md § Repository Cloning):
 
 ```bash
-mkdir -p repos/{owner}_{repo}--worktrees
+WT_PATH="$WT_DIR/{prefix}--{number}-{slug}"
+mkdir -p "$WT_DIR"
 
-git -C repos/{owner}_{repo} worktree add \
-  ../repos/{owner}_{repo}--worktrees/{prefix}--{number}-{slug} \
-  -b {prefix}/{number}-{slug}
+git -C "$REPO_PATH" worktree add "$WT_PATH" -b {prefix}/{number}-{slug}
 ```
 
 Spawn all fast-path agents in a **single Task tool message** using `subagent_type: general-purpose`. See `../shared/references/agent-spawning.md` § Parallel Execution Pattern.
@@ -347,7 +396,7 @@ Check GSD is installed per `../shared/references/gsd-integration.md` § GSD Dete
 Create a worktree for the issue (same as fast path), then set up GSD's `.planning/` directory inside it:
 
 ```bash
-mkdir -p repos/{owner}_{repo}--worktrees/{prefix}--{number}-{slug}/.planning
+mkdir -p "$WT_DIR/{prefix}--{number}-{slug}/.planning"
 ```
 
 Write `.planning/PROJECT.md` with the issue context:
@@ -556,6 +605,8 @@ Fixes #{number}
 | Re-running on existing items | Issues with `status:in-progress` + open PR are skipped in batch |
 | Active blocker in state issue | Skip the issue; report blocker in plan |
 | Mixed batch (fast + GSD) | Execute fast-path issues in parallel first, then GSD issues sequentially |
+| No issue number provided | Create-and-implement mode — investigate repo, create issue, then implement |
+| Labels missing on target repo | Check labels first; use fallback mapping to GitHub defaults or omit labels |
 
 ## Examples
 
@@ -574,3 +625,7 @@ Flow: Read state issue -> fetch 5 triaged issues -> assess complexity (3 Low, 1 
 **Example 4: User forces GSD on a simple issue**
 User: "use GSD for issue #42"
 Flow: Same as Example 2 but skipping complexity assessment — user override wins.
+
+**Example 5: Create-and-implement (no issue number)**
+User: "/ghs-issue-implement owner/repo refresh readme for .NET 10 migration"
+Flow: Investigate repo (read README, global.json, csproj) -> check existing labels on repo -> create issue #32 with `documentation` label (repo doesn't have `type:docs`) -> assess complexity:Low -> route to FAST -> show plan -> implement -> PR -> report.

--- a/.claude/skills/shared/references/agent-spawning.md
+++ b/.claude/skills/shared/references/agent-spawning.md
@@ -4,21 +4,28 @@ Patterns for parallel worktree-based agent execution. Used by ghs-repo-scan, ghs
 
 ## Repository Cloning
 
-Repos are cloned to `repos/` (gitignored, ephemeral working copies):
+Repos are cloned to `repos/` (gitignored, ephemeral working copies).
+
+**Important:** All paths must be resolved to **absolute paths** before use. Relative paths like `repos/{owner}_{repo}` break when the working directory changes (e.g., after `cd`, inside subagents, or when the skill runs from a different directory). Compute `GHS_ROOT` once at the start of the skill and derive all paths from it.
 
 ```bash
-if [ -d "repos/{owner}_{repo}" ]; then
-  git -C repos/{owner}_{repo} pull
+# Resolve GHS_ROOT once at skill start (the GitHubSkills project root)
+GHS_ROOT="$(cd "$(dirname "$(git rev-parse --git-dir)")" && pwd)"
+REPO_PATH="$GHS_ROOT/repos/{owner}_{repo}"
+WT_DIR="$GHS_ROOT/repos/{owner}_{repo}--worktrees"
+
+if [ -d "$REPO_PATH" ]; then
+  git -C "$REPO_PATH" pull --ff-only
 else
-  mkdir -p repos
-  gh repo clone {owner}/{repo} repos/{owner}_{repo}
+  mkdir -p "$GHS_ROOT/repos"
+  gh repo clone {owner}/{repo} "$REPO_PATH"
 fi
 ```
 
 Detect default branch after clone/pull:
 
 ```bash
-git -C repos/{owner}_{repo} rev-parse --abbrev-ref HEAD
+git -C "$REPO_PATH" rev-parse --abbrev-ref HEAD
 ```
 
 ## Worktree Creation
@@ -33,11 +40,10 @@ repos/{owner}_{repo}--worktrees/{prefix}--{slug}/      <- one worktree per item
 ### Create
 
 ```bash
-mkdir -p repos/{owner}_{repo}--worktrees
+WT_PATH="$WT_DIR/{prefix}--{slug}"
+mkdir -p "$WT_DIR"
 
-git -C repos/{owner}_{repo} worktree add \
-  ../repos/{owner}_{repo}--worktrees/{prefix}--{slug} \
-  -b {prefix}/{slug}
+git -C "$REPO_PATH" worktree add "$WT_PATH" -b {prefix}/{slug}
 ```
 
 ### Branch Prefix Convention
@@ -57,7 +63,7 @@ Before creating worktrees, check for conflicts:
 
 ```bash
 # Existing remote branches
-git -C repos/{owner}_{repo} ls-remote --heads origin 'refs/heads/{prefix}/*'
+git -C "$REPO_PATH" ls-remote --heads origin 'refs/heads/{prefix}/*'
 
 # Existing PRs for branch
 gh pr list --repo {owner}/{repo} --head {prefix}/{slug} --json number,url
@@ -195,14 +201,13 @@ Content filter failures: retry with download-based approach (see `../edge-cases.
 
 ```bash
 # Remove completed/failed worktrees
-git -C repos/{owner}_{repo} worktree remove \
-  ../repos/{owner}_{repo}--worktrees/{prefix}--{slug} --force
+git -C "$REPO_PATH" worktree remove "$WT_DIR/{prefix}--{slug}" --force
 
 # Prune stale worktree references
-git -C repos/{owner}_{repo} worktree prune
+git -C "$REPO_PATH" worktree prune
 
 # Remove directory if empty
-rmdir repos/{owner}_{repo}--worktrees 2>/dev/null || true
+rmdir "$WT_DIR" 2>/dev/null || true
 ```
 
 NEEDS_HUMAN worktrees are **not** cleaned up -- left in place with instructions for manual continuation.

--- a/.claude/skills/shared/references/implementation-workflow.md
+++ b/.claude/skills/shared/references/implementation-workflow.md
@@ -6,22 +6,32 @@ Reusable patterns for skills that clone repositories, create worktrees, and prod
 
 ## §1 — Repository Preparation
 
+### Path Resolution
+
+All paths must be **absolute** to avoid breakage when the working directory changes (e.g., inside subagents, after `cd`, or when skills run from different directories). Compute the root path once at the start:
+
+```bash
+# Resolve GHS_ROOT once at skill start (the GitHubSkills project root)
+GHS_ROOT="$(cd "$(dirname "$(git rev-parse --git-dir)")" && pwd)"
+REPO_PATH="$GHS_ROOT/repos/{owner}_{repo}"
+WT_DIR="$GHS_ROOT/repos/{owner}_{repo}--worktrees"
+```
+
 ### Clone or Pull
 
 ```bash
-# Check if already cloned
-if [ -d "repos/{owner}_{repo}" ]; then
-  git -C repos/{owner}_{repo} pull
+if [ -d "$REPO_PATH" ]; then
+  git -C "$REPO_PATH" pull --ff-only
 else
-  mkdir -p repos
-  gh repo clone {owner}/{repo} repos/{owner}_{repo}
+  mkdir -p "$GHS_ROOT/repos"
+  gh repo clone {owner}/{repo} "$REPO_PATH"
 fi
 ```
 
 ### Default Branch Detection
 
 ```bash
-git -C repos/{owner}_{repo} rev-parse --abbrev-ref HEAD
+git -C "$REPO_PATH" rev-parse --abbrev-ref HEAD
 ```
 
 ### Tech Stack Detection
@@ -59,25 +69,23 @@ repos/{owner}_{repo}--worktrees/{prefix}--{slug}/      ← one worktree per item
 ### Creation
 
 ```bash
-mkdir -p repos/{owner}_{repo}--worktrees
+WT_PATH="$WT_DIR/{prefix}--{slug}"
+mkdir -p "$WT_DIR"
 
-git -C repos/{owner}_{repo} worktree add \
-  ../repos/{owner}_{repo}--worktrees/{prefix}--{slug} \
-  -b {prefix}/{slug}
+git -C "$REPO_PATH" worktree add "$WT_PATH" -b {prefix}/{slug}
 ```
 
 ### Cleanup
 
 ```bash
 # For each completed item (PASS or FAILED, not NEEDS_HUMAN):
-git -C repos/{owner}_{repo} worktree remove \
-  ../repos/{owner}_{repo}--worktrees/{prefix}--{slug} --force
+git -C "$REPO_PATH" worktree remove "$WT_DIR/{prefix}--{slug}" --force
 
 # After all removals:
-git -C repos/{owner}_{repo} worktree prune
+git -C "$REPO_PATH" worktree prune
 
 # Remove the worktrees directory if empty:
-rmdir repos/{owner}_{repo}--worktrees 2>/dev/null || true
+rmdir "$WT_DIR" 2>/dev/null || true
 ```
 
 ### NEEDS_HUMAN Retention
@@ -164,7 +172,7 @@ For Category A agents handling multiple items, return a JSON **array** of these 
 Before creating worktrees, check for existing remote branches:
 
 ```bash
-git -C repos/{owner}_{repo} ls-remote --heads origin 'refs/heads/{prefix}/*'
+git -C "$REPO_PATH" ls-remote --heads origin 'refs/heads/{prefix}/*'
 ```
 
 Flag any conflicts in the plan table with a warning indicator. If the user confirms, use the `-B` flag on `worktree add` to force-create the branch.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -158,16 +158,41 @@ export default withMermaid(
         ],
         '/reference/': [
           {
-            text: 'Reference',
+            text: 'Scoring & Format',
             items: [
               { text: 'Scoring', link: '/reference/scoring' },
               { text: 'GitHub Projects Format', link: '/reference/backlog-format' },
               { text: 'Check Format', link: '/reference/check-format' },
+              { text: 'Item Categories', link: '/reference/item-categories' },
+              { text: 'Config Constants', link: '/reference/config' },
+            ],
+          },
+          {
+            text: 'Agent Patterns',
+            items: [
+              { text: 'Agent Spawning', link: '/reference/agent-spawning' },
               { text: 'Agent Contract', link: '/reference/agent-contract' },
+              { text: 'Implementation Workflow', link: '/reference/implementation-workflow' },
+            ],
+          },
+          {
+            text: 'CLI & Output',
+            items: [
+              { text: 'gh CLI Patterns', link: '/reference/gh-cli-patterns' },
               { text: 'Argument Parsing', link: '/reference/argument-parsing' },
-              { text: 'Checkpoint Patterns', link: '/reference/checkpoint-patterns' },
+              { text: 'Output Conventions', link: '/reference/output-conventions' },
               { text: 'UI Branding', link: '/reference/ui-brand' },
               { text: 'Output Templates', link: '/reference/templates' },
+              { text: 'Checkpoint Patterns', link: '/reference/checkpoint-patterns' },
+            ],
+          },
+          {
+            text: 'Integration',
+            items: [
+              { text: 'GSD Integration', link: '/reference/gsd-integration' },
+              { text: 'State Persistence', link: '/reference/state-persistence' },
+              { text: 'Sync Format', link: '/reference/sync-format' },
+              { text: 'Edge Cases', link: '/reference/edge-cases' },
             ],
           },
         ],

--- a/docs/reference/agent-spawning.md
+++ b/docs/reference/agent-spawning.md
@@ -1,0 +1,102 @@
+# Agent Spawning
+
+Patterns for parallel worktree-based agent execution. GHS spawns sub-agents to perform health fixes and issue implementations concurrently, each in its own git worktree.
+
+## Repository Cloning
+
+Repos are cloned to `repos/` (gitignored). All paths must be resolved to **absolute paths** before use --- relative paths break inside subagents.
+
+```bash
+GHS_ROOT="$(cd "$(dirname "$(git rev-parse --git-dir)")" && pwd)"
+REPO_PATH="$GHS_ROOT/repos/{owner}_{repo}"
+WT_DIR="$GHS_ROOT/repos/{owner}_{repo}--worktrees"
+```
+
+## Worktree Layout
+
+Worktrees are **siblings** to the main clone, never nested inside it (nesting corrupts the git index):
+
+```
+repos/{owner}_{repo}/                                  <- main clone
+repos/{owner}_{repo}--worktrees/{prefix}--{slug}/      <- one worktree per item
+```
+
+### Branch Prefix Convention
+
+| Source | Prefix | Example |
+|--------|--------|---------|
+| Health fix | `fix/` | `fix/license` |
+| Bug issue | `fix/` | `fix/42-login-crash` |
+| Feature issue | `feat/` | `feat/15-dark-mode` |
+| Docs issue | `docs/` | `docs/18-update-readme` |
+| Default | `impl/` | `impl/50-misc-task` |
+
+## Parallel Execution
+
+All agents are spawned via the Task tool with `subagent_type: general-purpose`. Agents are launched in a **single Task tool message** for parallel execution.
+
+| Skill | Agents Spawned |
+|-------|----------------|
+| ghs-repo-scan | 3 health check agents (one per tier) + 1 issues agent |
+| ghs-backlog-fix | 1 Category A agent + N Category B agents + optional CI agent |
+| ghs-issue-implement | N implementation agents (one per issue) |
+
+## Agent Categories
+
+| Category | Description | Worktree? | Agent Count |
+|----------|-------------|-----------|-------------|
+| **A** (API-only) | `gh` commands, no file changes | No | 1 (handles all API items) |
+| **B** (file changes) | Create/modify files, commit, push, PR | Yes --- one each | 1 per item |
+| **CI** (special) | Diagnose CI failures before fixing | Yes | 1 per CI item |
+
+## Context Budgeting
+
+Each agent prompt includes:
+
+- Repository info: owner, repo, default branch
+- Item-specific info: tier, slug, check details, acceptance criteria
+- Worktree path (for B/CI agents)
+- Tech stack detection results
+- Synced issue number (for `Fixes #N` in commits)
+- Analysis comment content (for issue-implement, if available)
+
+Agents return results via the [Agent Result Contract](./agent-contract) --- they do not write to the GitHub Project directly.
+
+## Wave-Based Execution
+
+When items have dependencies, agents are organized into waves instead of flat parallel execution.
+
+### Dependency Examples
+
+| Item | Depends On | Reason |
+|------|-----------|--------|
+| CI workflow health | .editorconfig, .gitignore | Workflows may reference these files |
+| Branch protection status checks | CI workflows | Checks require passing workflows |
+| Contributing guide | LICENSE, README | Links to these files |
+
+### Wave Construction
+
+1. Items with no dependencies go to Wave 1
+2. Items whose dependencies are all in Wave 1 go to Wave 2
+3. Repeat until all items are assigned
+4. Circular dependencies are flagged as NEEDS_HUMAN
+
+Flat parallel (single wave) is the default. Waves activate only when the dependency graph has edges.
+
+## Bounded Retries
+
+| Attempt | Action |
+|---------|--------|
+| 1st failure | Re-run with error context appended |
+| 2nd failure | Re-run with error + stricter constraints |
+| 3rd failure | Mark as `NEEDS_HUMAN`, preserve worktree |
+
+## Worktree Cleanup
+
+Completed and failed worktrees are removed after execution. NEEDS_HUMAN worktrees are left in place with instructions for manual continuation.
+
+```bash
+git -C "$REPO_PATH" worktree remove "$WT_DIR/{prefix}--{slug}" --force
+git -C "$REPO_PATH" worktree prune
+rmdir "$WT_DIR" 2>/dev/null || true
+```

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,0 +1,62 @@
+# Configuration Constants
+
+Centralized configuration values used across multiple skills. Skills reference these constants instead of hardcoding values to prevent drift.
+
+## Scoring
+
+| Constant | Value | Used By |
+|----------|-------|---------|
+| Tier 1 points | 4 | repo-scan, backlog-score, backlog-board, backlog-next |
+| Tier 2 points | 2 | repo-scan, backlog-score, backlog-board, backlog-next |
+| Tier 3 points | 1 | repo-scan, backlog-score, backlog-board, backlog-next |
+| Core max points | 74 | backlog-score |
+| .NET max points | 34 | backlog-score |
+| Core weight (with lang module) | 60% | repo-scan, backlog-score |
+| Language module weight | 40% | repo-scan, backlog-score |
+
+## Modules
+
+| Module | Slug | Detection Marker | Project Field Value |
+|--------|------|------------------|---------------------|
+| Core | `core` | Always active | `core` |
+| .NET | `dotnet` | `*.sln` in repo root | `dotnet` |
+
+## Display
+
+| Constant | Value |
+|----------|-------|
+| Progress bar width | 8 characters |
+| Progress bar filled char | `\u2588` |
+| Progress bar empty char | `\u2591` |
+| Max terminal issues | 20 |
+| Issue body truncation | 500 chars |
+| Title kebab truncation | 50 chars |
+
+## Thresholds
+
+| Constant | Value |
+|----------|-------|
+| Stale scan threshold | 30 days |
+| Max issues fetched | 500 |
+| Classification body limit | 2000 chars |
+
+## GitHub Projects
+
+| Constant | Value |
+|----------|-------|
+| Project title prefix | `[GHS]` |
+| Project title format | `[GHS] {owner}/{repo}` |
+| State issue label | `ghs:state` |
+| State issue title | `[GHS State] {owner}/{repo}` |
+| Score item title | `[GHS Score]` |
+| Health item title prefix | `[Health]` |
+| Auth scope required | `project` |
+
+## Status Indicators
+
+| Indicator | Meaning |
+|-----------|---------|
+| `[PASS]` | Check passed |
+| `[FAIL]` | Check failed |
+| `[WARN]` | Cannot verify (permissions) |
+| `[INFO]` | Informational only (no score impact) |

--- a/docs/reference/edge-cases.md
+++ b/docs/reference/edge-cases.md
@@ -1,0 +1,64 @@
+# Edge Cases
+
+Common edge case handling patterns shared across all GHS skills. Centralizing these avoids drift between skills that face the same situations.
+
+## Rate Limiting
+
+GitHub's API allows 5,000 requests/hour for authenticated users. When rate-limited:
+
+1. The `gh` CLI returns a 403 with "rate limit exceeded"
+2. Report the error to the user with the reset time
+3. Do not retry in a loop --- this wastes tokens and won't resolve until the window resets
+4. Suggest the user wait and re-run the skill
+
+## Content Filter Workaround
+
+Some files (notably Code of Conduct) trigger API content filters when generated inline.
+
+**Detection:** Agent fails with "Output blocked by content filtering policy"
+
+**Handling:** Download the canonical version from an official URL instead of generating inline, then customize placeholders:
+
+```bash
+curl -sL "https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md" \
+  -o CODE_OF_CONDUCT.md
+sed -i '' 's/\[INSERT CONTACT METHOD\]/via GitHub issues/' CODE_OF_CONDUCT.md
+```
+
+The orchestrator detects content filter failures and retries with the download-based approach automatically.
+
+## Permission Errors (403)
+
+| Context | Meaning | Action |
+|---------|---------|--------|
+| Branch protection check | Requires admin access | Report as WARN |
+| Security alerts | May require security admin role | Report as WARN |
+| Push to repo | User lacks write access | Report as FAILED |
+| Label creation | May require maintainer role | Skip label, continue |
+| Org-level settings | Managed at org level | Note the possibility |
+
+## gh CLI Error Handling
+
+Append `2>&1 || true` to `gh` commands that may return non-zero for expected conditions. A 404 on a resource check means "doesn't exist yet" (useful information), not a runtime error.
+
+## Bounded Agent Retries
+
+| Retry Count | Action |
+|-------------|--------|
+| 0 (first failure) | Re-run with error context appended |
+| 1 (second failure) | Re-run with error + stricter constraints |
+| 2+ (third failure) | Mark as `NEEDS_HUMAN`, preserve worktree |
+
+Two retries catches transient issues; persistent failures need human judgment.
+
+## Special Repository Situations
+
+| Situation | Handling |
+|-----------|----------|
+| **Private repos** | All `gh` checks work if the user has access. Note visibility in reports. |
+| **Org-level settings** | Branch protection and security may be org-managed. Report 403s as WARN. |
+| **Forks** | Inherit settings from upstream. Note in reports; some checks may not apply. |
+| **Empty/new repos** | Many checks naturally fail. Add a note to focus on Tier 1 first. |
+| **Archived repos** | Warn that changes cannot be pushed. Scanning still works for information. |
+| **Repos with many issues** | Cap terminal display at 20 issues. Note overflow count. |
+| **Long issue bodies** | Truncate to 500 chars with "..." and a link to the full issue. |

--- a/docs/reference/gh-cli-patterns.md
+++ b/docs/reference/gh-cli-patterns.md
@@ -1,0 +1,120 @@
+# gh CLI Patterns
+
+Common `gh` CLI patterns used across all GHS skills. All GitHub API interactions must use `gh` --- it handles authentication, pagination, and rate limiting automatically.
+
+## Authentication
+
+```bash
+gh auth status
+```
+
+If this fails, instruct the user to run `gh auth login`. For project operations, verify the `project` scope:
+
+```bash
+gh auth status 2>&1 | grep -q "project" || echo "[FAIL] Run: gh auth refresh -s project"
+```
+
+## Repo Detection
+
+| Priority | Source | Command |
+|----------|--------|---------|
+| 1 | Explicit argument | `owner/repo` from user input |
+| 2 | Git remote | `gh repo view --json nameWithOwner -q '.nameWithOwner'` |
+| 3 | Ask user | Prompt if detection fails |
+
+## Repo Metadata Queries
+
+| Query | Command |
+|-------|---------|
+| Default branch | `gh repo view {owner}/{repo} --json defaultBranchRef -q '.defaultBranchRef.name'` |
+| Visibility | `gh repo view {owner}/{repo} --json isPrivate -q '.isPrivate'` |
+| Fork status | `gh repo view {owner}/{repo} --json isFork,parent -q '{fork: .isFork, parent: .parent.nameWithOwner}'` |
+| Owner type | `gh repo view {owner}/{repo} --json owner -q '.owner.type'` |
+| Viewer permission | `gh repo view --json viewerPermission` |
+| Authenticated user | `gh api user --jq '.login'` |
+
+## Issue Operations
+
+```bash
+# List open issues
+gh issue list --repo {owner}/{repo} --state open --json number,title,body,labels --limit 100
+
+# View single issue
+gh issue view {number} --repo {owner}/{repo} --json number,title,body,labels,comments,state
+
+# Create issue
+gh issue create --title "{title}" --body "{body}" --label "{labels}" --repo {owner}/{repo}
+
+# Edit labels
+gh issue edit {number} --repo {owner}/{repo} --add-label "{labels}"
+
+# Comment on issue
+gh issue comment {number} --body "{comment}" --repo {owner}/{repo}
+```
+
+## PR Operations
+
+```bash
+# List open PRs with CI status
+gh pr list --repo {owner}/{repo} --state open \
+  --json number,title,headRefName,statusCheckRollup,mergeable,reviewDecision --limit 100
+
+# Create PR
+gh pr create --repo {owner}/{repo} \
+  --head {prefix}/{slug} --base {default_branch} \
+  --title "{title}" --body "{body}"
+
+# Merge PR
+gh pr merge {number} --repo {owner}/{repo} --squash --delete-branch
+```
+
+## Label Operations
+
+```bash
+# List labels
+gh label list --repo {owner}/{repo} --json name --jq '.[].name'
+
+# Create label (idempotent)
+gh label create "{name}" --color "{hex}" --description "{desc}" --repo {owner}/{repo} 2>&1 || true
+```
+
+## Project Operations
+
+GitHub Projects (ProjectsV2) track health findings per repository. Key operations:
+
+```bash
+# List projects (filter by GHS prefix)
+gh project list --owner {owner} --format json --jq '.projects[] | select(.title | startswith("[GHS]"))'
+
+# Add draft item
+gh project item-create {number} --owner {owner} --title "{title}" --body "{body}" --format json
+
+# List items
+gh project item-list {number} --owner {owner} --format json --limit 500
+
+# Edit item field (requires 3-ID lookup: project ID, item ID, field ID)
+gh project item-edit --project-id {project_node_id} --id {item_node_id} --field-id {field_node_id} --text "{value}"
+```
+
+## Tech Stack Detection
+
+| File(s) | Tech Stack |
+|---------|------------|
+| `*.csproj`, `*.sln` | .NET |
+| `package.json` | Node.js / JavaScript |
+| `Cargo.toml` | Rust |
+| `go.mod` | Go |
+| `pyproject.toml`, `setup.py` | Python |
+| `Gemfile` | Ruby |
+| `pom.xml`, `build.gradle` | Java / JVM |
+
+## Error Handling
+
+| HTTP Status | Meaning | Action |
+|-------------|---------|--------|
+| 200 | Success | Process normally |
+| 404 | Not found | Resource doesn't exist --- legitimate FAIL |
+| 403 | Forbidden | Insufficient permissions --- report as WARN |
+| 429 / rate limit | Rate limited | Report to user, do not retry in a loop |
+
+Append `2>&1 || true` to `gh` commands that may return non-zero for expected conditions (e.g., label creation, resource checks returning 404).

--- a/docs/reference/gsd-integration.md
+++ b/docs/reference/gsd-integration.md
@@ -1,0 +1,102 @@
+# GSD Integration
+
+How GHS skills invoke the [GSD framework](https://github.com/gsd-build/get-shit-done) for complex, multi-phase implementation tasks. GSD is a **hard dependency** --- skills that need it fail fast with a clear message if GSD is not installed.
+
+## GSD Detection
+
+Before invoking GSD commands, verify installation:
+
+```bash
+ls ~/.claude/commands/gsd:* 2>/dev/null || ls ~/.claude/plugins/*/skills/gsd-*/SKILL.md 2>/dev/null
+```
+
+If not found, emit an error with install instructions and stop. Do not fall back to a simpler approach --- the complexity warrants GSD.
+
+## Complexity Routing
+
+Not every task needs GSD. The routing decision determines whether a task takes the **fast path** (single-shot agent) or the **GSD path** (multi-phase planning and execution).
+
+### Decision Matrix
+
+| Signal | Fast Path | GSD Path |
+|--------|-----------|----------|
+| Complexity rating | Low, Medium | High, Very High |
+| Estimated files changed | 1--3 | 4+ |
+| Cross-cutting concerns | None | Multiple modules, tests, docs |
+| Issue has sub-tasks | No | Yes |
+| Requires architectural decisions | No | Yes |
+
+### Routing Rules
+
+1. **Explicit user override always wins** --- "just do it quick" or "use GSD for this"
+2. **ghs-issue-analyze is the primary signal** --- use its complexity rating directly
+3. **When no analysis exists**, estimate from issue body (acceptance criteria count, file mentions, keywords like "refactor" or "migration")
+4. **Default to fast path** when signals are ambiguous
+
+### Complexity Levels
+
+| Level | Criteria | Example |
+|-------|----------|---------|
+| **Low** | Single file, clear fix | Typo in README |
+| **Medium** | 2--3 files, straightforward | Add form validation |
+| **High** | 4+ files, cross-module, tests required | New API endpoint with auth |
+| **Very High** | Architectural change, multiple subsystems | Auth system rewrite |
+
+## GSD Command Flow
+
+### Implementation (ghs-issue-implement, GSD path)
+
+```
+Step 1: Prepare context     -> Write PROJECT.md with repo + issue details
+Step 2: /gsd:discuss-phase  -> Capture implementation preferences
+Step 3: /gsd:plan-phase     -> Create atomic task plans (PLAN.md files)
+Step 4: /gsd:execute-phase  -> Wave-based execution, fresh context per task
+Step 5: /gsd:verify-work    -> Automated acceptance testing
+```
+
+### Health Fix (ghs-backlog-fix, wave-based)
+
+For multi-item batches with dependencies, GSD provides wave-based execution without full planning:
+
+```
+Step 1: Classify items + build dependency graph
+Step 2: /gsd:execute-phase with wave definitions
+Step 3: Verify per wave, report progress incrementally
+```
+
+### Quick Tasks
+
+For simple tasks that benefit from GSD's quality guarantees:
+
+```
+/gsd:quick "Add LICENSE file to repository"
+```
+
+## Skill-to-GSD Contract
+
+### What GHS provides to GSD
+
+| Artifact | Location | Content |
+|----------|----------|---------|
+| `PROJECT.md` | `.planning/PROJECT.md` | Repo name, tech stack, issue details, acceptance criteria |
+| `REQUIREMENTS.md` | `.planning/REQUIREMENTS.md` | Extracted from issue body + analysis comment |
+| Issue context | Discuss phase | Full issue body, comments, labels |
+
+### What GSD returns to GHS
+
+| Artifact | Location | Content |
+|----------|----------|---------|
+| Git commits | In worktree/branch | Atomic commits per task |
+| Verification | `.planning/{N}-VERIFICATION.md` | Pass/fail per acceptance criterion |
+
+GSD handles implementation but does **not** create PRs --- the GHS orchestrator pushes the branch, creates the PR, and updates backlog status.
+
+## Error Handling
+
+| Failure | Action |
+|---------|--------|
+| GSD not installed | Fail fast with install instructions |
+| Plan validation fails 3 times | Mark as NEEDS_HUMAN, preserve worktree |
+| Execute task fails | GSD handles retries internally |
+| Verify finds failures | GSD generates fix plans; orchestrator re-executes or escalates |
+| 3 consecutive command failures | Preserve worktree, suggest fast path fallback, mark NEEDS_HUMAN |

--- a/docs/reference/implementation-workflow.md
+++ b/docs/reference/implementation-workflow.md
@@ -1,0 +1,123 @@
+# Implementation Workflow
+
+Reusable patterns for skills that clone repositories, create worktrees, and produce PRs. Referenced by ghs-backlog-fix and ghs-issue-implement.
+
+## Repository Preparation
+
+### Path Resolution
+
+All paths must be **absolute** to avoid breakage inside subagents or after directory changes:
+
+```bash
+GHS_ROOT="$(cd "$(dirname "$(git rev-parse --git-dir)")" && pwd)"
+REPO_PATH="$GHS_ROOT/repos/{owner}_{repo}"
+WT_DIR="$GHS_ROOT/repos/{owner}_{repo}--worktrees"
+```
+
+### Clone or Pull
+
+```bash
+if [ -d "$REPO_PATH" ]; then
+  git -C "$REPO_PATH" pull --ff-only
+else
+  mkdir -p "$GHS_ROOT/repos"
+  gh repo clone {owner}/{repo} "$REPO_PATH"
+fi
+```
+
+### Tech Stack Detection
+
+| File | Stack |
+|------|-------|
+| `*.csproj`, `*.sln` | .NET |
+| `package.json` | Node.js / JavaScript |
+| `Cargo.toml` | Rust |
+| `go.mod` | Go |
+| `pyproject.toml`, `setup.py` | Python |
+| `Gemfile` | Ruby |
+| `pom.xml`, `build.gradle` | Java / JVM |
+
+## Worktree Management
+
+### Layout
+
+```
+repos/{owner}_{repo}/                                  <- main clone (default branch)
+repos/{owner}_{repo}--worktrees/{prefix}--{slug}/      <- one worktree per item
+```
+
+Worktrees are **siblings** to the main clone, never nested inside it. The `repos/` directory is gitignored.
+
+### Creation
+
+```bash
+WT_PATH="$WT_DIR/{prefix}--{slug}"
+mkdir -p "$WT_DIR"
+git -C "$REPO_PATH" worktree add "$WT_PATH" -b {prefix}/{slug}
+```
+
+### Cleanup
+
+Completed and failed worktrees are removed. NEEDS_HUMAN worktrees are left in place with instructions:
+
+```
+[NEEDS_HUMAN] {slug} --- worktree left at repos/{owner}_{repo}--worktrees/{prefix}--{slug}/
+  To continue: cd repos/{owner}_{repo}--worktrees/{prefix}--{slug}
+  To remove:   git -C repos/{owner}_{repo} worktree remove <path>
+```
+
+## Branch / Commit / Push / PR
+
+Each agent in a worktree follows this workflow:
+
+1. **Make changes** in the worktree directory only
+2. **Stage**: `git -C {worktree_path} add {files}`
+3. **Commit**: `git -C {worktree_path} commit -m "{message}"`
+4. **Push**: `git -C {worktree_path} push -u origin {prefix}/{slug}`
+5. **Create PR**: `gh pr create --repo {owner}/{repo} --head {prefix}/{slug} --base {default_branch} --title "{title}" --body "{body}"`
+
+For issues, include `Fixes #{number}` in the commit or PR body to trigger GitHub's auto-close on merge.
+
+## Pre-flight Checks
+
+### Branch Conflict Detection
+
+```bash
+git -C "$REPO_PATH" ls-remote --heads origin 'refs/heads/{prefix}/*'
+```
+
+If a branch exists and the user confirms, use `-B` to force-create.
+
+### Existing PR Detection
+
+```bash
+gh pr list --repo {owner}/{repo} --head {prefix}/{slug} --json number,url
+```
+
+If a PR already exists, skip creation and report the existing URL.
+
+## Content Filter Workaround
+
+If an agent fails with "Output blocked by content filtering policy", retry with a download-based approach:
+
+```bash
+curl -sL "{canonical_url}" -o {filename}
+sed -i '' 's/\[INSERT CONTACT METHOD\]/via GitHub issues/' {filename}
+```
+
+## Agent Result Contract
+
+Every agent returns a fenced JSON result:
+
+```json
+{
+  "source": "health|issue",
+  "slug": "{identifier}",
+  "status": "PASS|FAILED|NEEDS_HUMAN",
+  "pr_url": "https://github.com/{owner}/{repo}/pull/N or null",
+  "verification": ["List of checks performed"],
+  "error": "Error message or null"
+}
+```
+
+See [Agent Result Contract](./agent-contract) for full details.

--- a/docs/reference/item-categories.md
+++ b/docs/reference/item-categories.md
@@ -1,0 +1,59 @@
+# Item Categories
+
+Classification of health check items by fix strategy. The orchestrator uses this classification to route items to the correct agent type and determine whether a worktree is needed.
+
+## Why Categories Matter
+
+Different checks need fundamentally different fix approaches:
+
+- **API-only fixes** (like setting a repo description) don't need file changes or branches
+- **File-change fixes** (like adding a LICENSE) need worktrees, branches, and PRs
+- **CI fixes** need a diagnostic step before any changes
+
+Routing items to the wrong category wastes resources or misses required steps.
+
+## Core Module Categories
+
+| Category | Description | Worktree? | Checks |
+|----------|-------------|-----------|--------|
+| **A** (API-only) | Uses `gh` commands directly | No | branch-protection, security-alerts, description, topics, delete-branch-on-merge, merge-strategy, homepage-url, stale-branches, github-releases |
+| **B** (file changes) | Creates/modifies files, commits, pushes, creates PR | Yes | license, editorconfig, codeowners, issue-templates, pr-template, security-md, contributing-md, code-of-conduct, readme, gitignore, ci-cd-workflows, changelog, gitattributes, version-pinning, dependency-update-config |
+| **CI** (special) | Diagnoses CI failures before fixing | Yes | ci-workflow-health, action-version-pinning, workflow-permissions, workflow-naming, workflow-timeouts, workflow-concurrency |
+
+## .NET Module Categories
+
+| Category | Description | Worktree? | Checks |
+|----------|-------------|-----------|--------|
+| **B** (file changes) | Modifies .NET project files | Yes | dotnet-build-props, dotnet-global-json, dotnet-central-packages, dotnet-nullable, dotnet-implicit-usings, dotnet-xml-docs, dotnet-warnings-as-errors, dotnet-deterministic, dotnet-analyzers, dotnet-analysis-level, dotnet-sourcelink, dotnet-local-tools, dotnet-nuget-metadata, dotnet-aot-ready |
+| **A** (inspection-only) | Read-only checks, no fix needed | No | dotnet-tests-exist, dotnet-solution-structure, dotnet-code-coverage, dotnet-benchmarks, dotnet-internals-visible, dotnet-multi-target |
+
+.NET INFO-only checks (`dotnet-target-framework`, `dotnet-package-count`, `dotnet-build-system`) never produce FAIL results and are never routed for fixing.
+
+## Classification Rules
+
+1. **Issue items** are always Category B --- they require code changes
+2. **Core health items** are classified by slug using the Core Module table
+3. **.NET health items** are classified by slug using the .NET Module table
+4. Unknown slugs default to Category B (file changes are the safe assumption)
+
+## Category Notes
+
+### Category A
+
+- All items handled by a single agent in one batch
+- No worktree or branch needed --- changes via GitHub API
+- Solo-maintainer repos use lightweight branch protection (no required PR reviews)
+- .NET Category A items are inspection-only --- fixes are too context-dependent to automate
+
+### Category B
+
+- One agent per item, each in its own worktree
+- Agent inspects the repo to produce context-aware content (not boilerplate)
+- PR body includes acceptance criteria as a checklist
+- .NET agents read existing `Directory.Build.props` and `.csproj` files before making changes
+
+### Category CI
+
+- Mandatory diagnostic step before any fix attempt
+- Must read actual CI failure logs (`gh run view --log-failed`)
+- Verify workflow YAML is valid after changes

--- a/docs/reference/output-conventions.md
+++ b/docs/reference/output-conventions.md
@@ -1,0 +1,115 @@
+# Output Conventions
+
+Terminal output patterns used across all GHS skills. Consistent formatting makes reports scannable and familiar.
+
+## Status Indicators
+
+| Indicator | Meaning |
+|-----------|---------|
+| `[PASS]` | Check passed / fix applied |
+| `[FAIL]` | Check failed / fix failed |
+| `[WARN]` | Cannot verify (permissions) |
+| `[INFO]` | Informational only |
+| `[NEEDS_HUMAN]` | Requires manual intervention |
+| `[FAILED]` | Agent/operation failed |
+
+## Health Check Report Structure
+
+```
+## Repository Scan: {owner}/{repo}
+
+### Health Checks
+
+#### Tier 1 --- Required
+  [PASS] README.md --- Found (2.3 KB)
+  [FAIL] LICENSE --- Not found
+  [WARN] Branch protection --- Unable to check (requires admin access)
+
+#### Tier 2 --- Recommended
+  [PASS] .gitignore --- Found
+  [FAIL] .editorconfig --- Not found
+
+### Health Score: 14/51 (27%)
+
+  Tier 1:  8/16  ████░░░░ (50%)
+  Tier 2:  6/26  ██░░░░░░ (23%)
+  Tier 3:  0/9   ░░░░░░░░ (0%)
+```
+
+## Progress Bar
+
+```
+Width:  8 characters
+Filled: █  (U+2588)
+Empty:  ░  (U+2591)
+```
+
+Filled count = `round(percentage / 100 x 8)`.
+
+## Table Patterns
+
+### Dashboard Table (multi-repo)
+
+```
+| Repository | Health | Progress | Issues | Open | PRs | Last Scan |
+|------------|--------|----------|--------|------|-----|-----------|
+| owner/repo | 10/31 (32%) | ██░░░░░░ | 18 | 15 | 3 | 2026-02-26 |
+```
+
+### Item List Table
+
+```
+| # | Item | Tier | Points | Status | Issue | PR |
+|---|------|------|--------|--------|-------|----|
+| 1 | README | 1 | 4 | FAIL | #42 | --- |
+```
+
+### Results Table (post-fix)
+
+```
+| Item | Tier | Pts | Status | PR |
+|------|------|-----|--------|----|
+| LICENSE | T1 | 4 | [PASS] | #12 |
+| Branch Protection | T1 | 4 | [PASS] | --- (API) |
+```
+
+### Batch Plan Table
+
+```
+| # | Item | Tier | Pts | Category | Issue | Branch | Worktree |
+|---|------|------|-----|----------|-------|--------|----------|
+| 1 | LICENSE | T1 | 4 | B (file) | #42 | fix/license | repos/.../ |
+```
+
+## Summary Blocks
+
+Each skill ends with a `Summary:` block. Key metrics per skill:
+
+| Skill | Summary Fields |
+|-------|---------------|
+| backlog-fix | Applied, PRs created, Points recovered, New health score |
+| backlog-sync | Created, Updated, Reopened, Closed, Already synced, Skipped |
+| issue-triage | Triaged count, Types breakdown, Priority breakdown |
+| merge-prs | Merged, Failed, Skipped |
+
+## Display Limits
+
+| Constant | Value |
+|----------|-------|
+| Max terminal issues | 20 (note "+N more" if exceeded) |
+| Issue body truncation | 500 chars |
+| Title kebab truncation | 50 chars |
+
+## Routing Suggestions
+
+Skills suggest next steps at the end of their output:
+
+| After | Suggest |
+|-------|---------|
+| repo-scan | backlog-sync, backlog-fix, backlog-board |
+| backlog-fix | merge-prs, backlog-board, repo-scan |
+| backlog-sync | backlog-fix, backlog-board |
+| issue-triage | issue-analyze, issue-implement |
+| issue-analyze | issue-implement |
+| issue-implement | merge-prs |
+| merge-prs | repo-scan, backlog-board |

--- a/docs/reference/state-persistence.md
+++ b/docs/reference/state-persistence.md
@@ -1,0 +1,120 @@
+# State Persistence
+
+Pattern for persisting session state using GitHub Issues. State is stored as a real GitHub Issue on the target repository, allowing decisions, blockers, and session history to survive across context resets.
+
+## Purpose
+
+Without state persistence, each session starts from scratch. The state issue records:
+
+- **What was attempted** --- items fixed, failed, or retried
+- **Decisions made** --- user preferences (PR strategy, merge method, skip lists)
+- **Blockers encountered** --- permission issues, API limits, content filter failures
+- **Session history** --- when each session ran and what it accomplished
+
+## State Issue Location
+
+State is stored as a GitHub Issue with the `ghs:state` label:
+
+```bash
+gh issue list --repo {owner}/{repo} --label "ghs:state" --state open \
+  --json number,title,body --limit 1
+```
+
+Title convention: `[GHS State] {owner}/{repo}`
+
+## State Issue Format
+
+### Issue Body (Decisions and Blockers)
+
+The body contains a machine-readable JSON block in an HTML comment plus human-readable markdown tables:
+
+```markdown
+<!-- ghs:state
+{
+  "decisions": [
+    {"decision": "PR merge method", "value": "squash", "set_by": "user", "date": "2026-02-28"}
+  ],
+  "blockers": [
+    {"blocker": "No admin access", "affected_items": ["branch-protection"], "status": "ACTIVE"}
+  ]
+}
+-->
+
+## Decisions
+
+| Decision | Value | Set By | Date |
+|----------|-------|--------|------|
+| PR merge method | squash | user | 2026-02-28 |
+
+## Blockers
+
+| Blocker | Affected Items | Status | Notes |
+|---------|---------------|--------|-------|
+| No admin access | branch-protection | ACTIVE | Need org admin |
+```
+
+The JSON in the HTML comment is the machine-readable source of truth. The markdown tables are human-readable duplicates for the GitHub UI.
+
+### Issue Comments (Session Entries)
+
+Each session appends a comment:
+
+```markdown
+## 2026-02-28 --- ghs-backlog-fix (batch)
+
+**Items attempted**: 5
+**Results**: 3 PASS, 1 FAILED, 1 NEEDS_HUMAN
+
+| Item | Status | PR | Notes |
+|------|--------|-----|-------|
+| tier-1--license | PASS | #42 | MIT license added |
+| tier-1--readme | PASS | #43 | Template applied |
+| tier-2--gitignore | FAILED | --- | Content filter |
+
+**Score change**: 45% -> 68% (+23)
+```
+
+## Lifecycle
+
+### Which Skills Create State Issues
+
+| Skill | Creates State? | Reason |
+|-------|-----------------------|--------|
+| ghs-backlog-fix | Yes | After first fix attempt |
+| ghs-issue-implement | Yes | After first implementation attempt |
+| ghs-action-fix | Yes | After first CI fix attempt |
+| ghs-repo-scan | No | Read-only |
+| ghs-backlog-board | No | Read-only dashboard |
+| ghs-backlog-sync | No | Syncs to project, no session state |
+
+### Reading State
+
+At the start of a mutation skill:
+
+1. Find the state issue by label
+2. Parse JSON from the HTML comment
+3. Read the latest 5 comments for session history
+
+From the parsed state:
+- **Active blockers** --- skip blocked items
+- **Decisions** --- apply user preferences
+- **Last session** --- show "Last activity: {date}"
+
+### Writing State
+
+- **Session comment**: Appended after each skill run with results table and score change
+- **Body update**: When decisions or blockers change, update the issue body JSON and tables
+- **New decisions**: Recorded when users state preferences or skills discover constraints
+- **New blockers**: Added when items fail due to external constraints
+- **Blocker resolution**: Status updated to RESOLVED when cleared
+
+## GSD Integration
+
+When ghs-issue-implement uses GSD, the GSD framework maintains its own `.planning/STATE.md` inside the worktree. The state issue captures the **outcome**, not GSD's internal state.
+
+| GSD's STATE.md | GHS State Issue |
+|----------------|-----------------|
+| Inside worktree | GitHub Issue on target repo |
+| Planning decisions | Repo-level preferences |
+| Phase progress | Session results and score changes |
+| Ephemeral (cleaned with worktree) | Persistent on GitHub |

--- a/docs/reference/sync-format.md
+++ b/docs/reference/sync-format.md
@@ -1,0 +1,85 @@
+# Sync Format
+
+Defines the contract for promoting draft health items in a GitHub Project to real GitHub Issues. Used by ghs-backlog-sync, ghs-backlog-fix, ghs-backlog-board, and ghs-backlog-next.
+
+## Label Taxonomy
+
+Labels created on the target repo during sync:
+
+| Label | Color | Description |
+|-------|-------|-------------|
+| `ghs:health-check` | `#7057ff` (purple) | Health check finding from ghs-repo-scan |
+| `tier:1` | `#d73a4a` (red) | Tier 1 --- Required |
+| `tier:2` | `#fbca04` (yellow) | Tier 2 --- Recommended |
+| `tier:3` | `#0e8a16` (green) | Tier 3 --- Nice to Have |
+| `category:api-only` | `#c5def5` (light blue) | Fix requires API calls only (Category A) |
+| `category:file-change` | `#bfd4f2` (blue) | Fix requires file changes (Category B) |
+| `category:ci` | `#d4c5f9` (lavender) | Fix requires CI workflow changes (Category CI) |
+
+All labels are created idempotently using `gh label create ... 2>&1 || true`.
+
+## Issue Title Convention
+
+```
+[Health] {Check Name}
+```
+
+The title is the dedup key --- if an issue with this exact title already exists (in any state), it is matched rather than creating a duplicate.
+
+Examples: `[Health] README`, `[Health] Branch Protection`, `[Health] .editorconfig`
+
+## Issue Body Template
+
+```markdown
+<!-- ghs-sync:metadata
+slug: {slug}
+tier: {tier_number}
+points: {points}
+category: {A|B|CI}
+detected: {YYYY-MM-DD}
+-->
+
+| Field | Value |
+|-------|-------|
+| **Tier** | {tier_number} --- {tier_label} |
+| **Points** | {points} |
+| **Category** | {category} |
+| **Detected** | {YYYY-MM-DD} |
+
+## What's Missing
+{description of the gap}
+
+## Why It Matters
+{explanation of impact}
+
+## How to Fix
+{remediation steps}
+
+## Acceptance Criteria
+- [ ] {criterion 1}
+- [ ] {criterion 2}
+```
+
+### Hidden Metadata Comment
+
+The `<!-- ghs-sync:metadata ... -->` block at the top is machine-readable and used to:
+
+1. Match issues back to project items (via `slug`)
+2. Preserve metadata even if the visible body is edited
+3. Detect content changes for update decisions
+
+Never strip or modify this comment when updating issue bodies.
+
+## Promotion Workflow
+
+When `ghs-backlog-sync` runs:
+
+1. Find draft items in the `Todo` column where `Source = Health Check`
+2. For each draft without a matching real issue (title-based dedup):
+   - Create a GitHub Issue with labels (`ghs:health-check`, `tier:N`, `category:*`)
+   - Delete the draft from the project
+   - Add the new issue to the project
+   - Copy custom field values (Tier, Points, Slug, Category, Detected)
+3. For items with existing matching issues: update if metadata changed, skip otherwise
+
+The `PR URL` custom field on the project item links findings to fix PRs created by ghs-backlog-fix.


### PR DESCRIPTION
## Summary
- Refine agent-spawning skills with improved worktree management, branch naming, and context passing
- Add 10 missing reference documentation pages for the docs website
- Reorganize the reference sidebar into logical groups (Scoring & Format, Agent Patterns, CLI & Output, Integration)

## Skill changes
- `.claude/skills/ghs-action-fix/SKILL.md` — Updated agent spawning patterns
- `.claude/skills/ghs-backlog-fix/SKILL.md` — Updated agent spawning patterns
- `.claude/skills/ghs-issue-implement/SKILL.md` — Enhanced implementation workflow
- `.claude/skills/shared/references/agent-spawning.md` — Refined worktree patterns
- `.claude/skills/shared/references/implementation-workflow.md` — Refined workflow steps

## Documentation additions
New reference pages: agent-spawning, config, edge-cases, gh-cli-patterns, gsd-integration, implementation-workflow, item-categories, output-conventions, state-persistence, sync-format

## Test plan
- [ ] Verify skill files parse correctly
- [ ] Run `npm run docs:dev` and confirm all new reference pages render
- [ ] Confirm sidebar navigation works with new grouping